### PR TITLE
Added some code to set the dvFilter options for ethernet[1] adapter

### DIFF
--- a/vsphere-6.0-vghetto-standard-lab-deployment.ps1
+++ b/vsphere-6.0-vghetto-standard-lab-deployment.ps1
@@ -194,6 +194,12 @@ if($deployNestedESXiVMs -eq 1) {
         sleep 60
 
         $vm | Get-NetworkAdapter -Server $pEsxi | Set-NetworkAdapter -Portgroup $network -confirm:$false | Out-File -Append -LiteralPath $verboseLogFile
+        
+        # Add the dvfilter settings to the exisiting ethernet1 (not part of ova template)
+        My-Logger "Correcting missing dvFilter settings for Ethernet[1] ..."
+        Get-VM $vm | New-AdvancedSetting -name "ethernet1.filter4.name" -value "dvfilter-maclearn" -confirm:$false -WarningAction SilentlyContinue | Out-File -Append -LiteralPath $verboseLogFile
+        Get-VM $vm | New-AdvancedSetting -Name "ethernet1.filter4.onFailure" -value "failOpen" -confirm:$false -WarningAction SilentlyContinue | Out-File -Append -LiteralPath $verboseLogFile
+        # End of Change
 
         My-Logger "Updating vCPU Count to $NestedESXivCPU & vMEM to $NestedESXivMEM GB ..."
         Set-VM -Server $pEsxi -VM $vm -NumCpu $NestedESXivCPU -MemoryGB $NestedESXivMEM -Confirm:$false | Out-File -Append -LiteralPath $verboseLogFile


### PR DESCRIPTION
While deploying several instances of the OVA I noticed that the second ethernet adapter was not setup for dvfilter adv settings. I added some code into the deployment script that will go ahead and set the required advanced values before the guest VM starts

Before
![capture](https://cloud.githubusercontent.com/assets/5621063/21465838/4f6bd9ba-c981-11e6-9715-f997b3c1e75c.PNG)

After
![capture2](https://cloud.githubusercontent.com/assets/5621063/21465840/57888454-c981-11e6-9149-8024fad49b7a.PNG)

