### PR TITLE
Change ESXi updates to pull from VMware

### DIFF
--- a/vsphere-6.5-vghetto-standard-lab-deployment.ps1
+++ b/vsphere-6.5-vghetto-standard-lab-deployment.ps1
@@ -40,13 +40,13 @@ $DeploymentTarget = "VCENTER"
 $NestedESXiApplianceOVA = "C:\Users\primp\Desktop\Nested_ESXi6.5_Appliance_Template_v1.ova"
 $VCSAInstallerPath = "C:\Users\primp\Desktop\VMware-VCSA-all-6.5.0-4944578"
 $NSXOVA =  "C:\Users\primp\Desktop\VMware-NSX-Manager-6.3.0-5007049.ova"
-$ESXi65aOfflineBundle = "C:\Users\primp\Desktop\ESXi650-201701001\vmw-ESXi-6.5.0-metadata.zip"
 
 # Nested ESXi VMs to deploy
 $NestedESXiHostnameToIPs = @{
-"vesxi65-1" = "172.30.0.171"
-"vesxi65-2" = "172.30.0.172"
-"vesxi65-3" = "172.30.0.173"
+"vesxi65-1" = "172.30.0.4"
+"vesxi65-2" = "172.30.0.5"
+"vesxi65-3" = "172.30.0.82"
+"vesti65-4" = "172.30.0.200"
 }
 
 # Nested ESXi VM Resources
@@ -113,7 +113,8 @@ $VXLANNetmask = "255.255.255.0"
 # Set to 1 only if you have DNS (forward/reverse) for ESXi hostnames
 $addHostByDnsName = 0
 # Upgrade vESXi hosts to 6.5a
-$upgradeESXiTo65a = 0
+$upgradeESXi = 0
+$ESXiProfileName = "ESXi-6.5.0-20170404001-standard"
 
 #### DO NOT EDIT BEYOND HERE ####
 
@@ -122,6 +123,7 @@ $vSphereVersion = "6.5"
 $deploymentType = "Standard"
 $random_string = -join ((65..90) + (97..122) | Get-Random -Count 8 | % {[char]$_})
 $VAppName = "vGhetto-Nested-vSphere-Lab-$vSphereVersion-$random_string"
+$depotServer = "https://hostupdate.vmware.com/software/VUM/PRODUCTION/main/vmw-depot-index.xml"
 
 $vcsaSize2MemoryStorageMap = @{
 "tiny"=@{"cpu"="2";"mem"="10";"disk"="250"};
@@ -192,13 +194,6 @@ if($preCheck -eq 1) {
         }
         $upgradeESXiTo65a = 1
     }
-
-    if($upgradeESXiTo65a -eq 1) {
-         if(!(Test-Path $ESXi65aOfflineBundle)) {
-            Write-Host -ForegroundColor Red "`nUnable to find $ESXi65aOfflineBundle ...`nexiting"
-            exit
-        }
-    }
 }
 
 if($confirmDeployment -eq 1) {
@@ -221,9 +216,9 @@ if($confirmDeployment -eq 1) {
         Write-Host -ForegroundColor White $NSXOVA
     }
 
-    if($upgradeESXiTo65a -eq 1) {
-        Write-Host -NoNewline -ForegroundColor Green "Extracted ESXi 6.5a Offline Patch Bundle Path: "
-        Write-Host -ForegroundColor White $ESXi65aOfflineBundle
+    if($upgradeESXi -eq 1) {
+        Write-Host -NoNewline -ForegroundColor Green "ESXi Image Profile name: "
+        Write-Host -ForegroundColor White $ESXiProfileName
     }
 
     if($DeploymentTarget -eq "ESXI") {
@@ -618,7 +613,8 @@ if($DeployNSX -eq 1) {
     }
 }
 
-if($upgradeESXiTo65a -eq 1) {
+if($upgradeESXi -eq 1) {
+    sleep 60
     $NestedESXiHostnameToIPs.GetEnumerator() | sort -Property Value | Foreach-Object {
         $VMName = $_.Key
         $VMIPAddress = $_.Value
@@ -629,9 +625,11 @@ if($upgradeESXiTo65a -eq 1) {
         My-Logger "Entering Maintenance Mode ..."
         Set-VMHost -VMhost $VMIPAddress -State Maintenance -Confirm:$false | Out-File -Append -LiteralPath $verboseLogFile
 
-        My-Logger "Upgrading $VMName to ESXi 6.5a ..."
-        Install-VMHostPatch -VMHost $VMIPAddress -LocalPath $ESXi65aOfflineBundle -HostUsername root -HostPassword $VMPassword -WarningAction SilentlyContinue -Confirm:$false | Out-File -Append -LiteralPath $verboseLogFile
-
+        My-Logger "Upgrading $VMName image profile ..."
+        $esxcli = Get-EsxCli -VMhost $VMIPAddress -V2
+        $esxcli.network.firewall.ruleset.set.Invoke(@{enabled = 'true' ; rulesetid = 'httpClient'}) | Out-Null 
+        $esxcli.software.profile.update.Invoke(@{profile = $ESXiProfileName; depot = $depotServer}) | Out-File -Append -LiteralPath $verboseLogFile
+        
         My-Logger "Rebooting $VMName ..."
         Restart-VMHost $VMIPAddress -RunAsync -Confirm:$false | Out-File -Append -LiteralPath $verboseLogFile
 


### PR DESCRIPTION
I thought it might be useful to allow patching of ESXi hosts directly from VMware, using the esxcli commands outlined here: https://tinkertry.com/easy-upgrade-to-esxi-60u1b. This avoids having to first download the offline bundle to your desktop. You just need to know the image profile name.

I decided to use this process because I couldn't get the original Install-VMHostPatch method to work with 6.5d. The boot drive on the ESXi ova was too small, and even with a larger drive I was still running into issues.

I realize some lab environments might not have internet access, in which case this change will not work.