### PR TITLE
Enable fake SCSI reservations for complete cluster

### DIFF
--- a/vsphere-6.7-vghetto-standard-lab-deployment.ps1
+++ b/vsphere-6.7-vghetto-standard-lab-deployment.ps1
@@ -462,10 +462,11 @@ if($DeploymentTarget -eq "ESXI") {
     $cluster = Get-Cluster -Server $viConnection -Name $VMCluster
     $datacenter = $cluster | Get-Datacenter
     $vmhost = $cluster | Get-VMHost | Select -First 1
+    $vmhostfullcluster = $cluster | Get-VMHost
 
     if($datastore.Type -eq "vsan") {
         My-Logger "VSAN Datastore detected, enabling Fake SCSI Reservations ..."
-        Get-AdvancedSetting -Entity $vmhost -Name "VSAN.FakeSCSIReservations" | Set-AdvancedSetting -Value 1 -Confirm:$false | Out-File -Append -LiteralPath $verboseLogFile
+        Get-AdvancedSetting -Entity $vmhostfullcluster -Name "VSAN.FakeSCSIReservations" | Set-AdvancedSetting -Value 1 -Confirm:$false | Out-File -Append -LiteralPath $verboseLogFile
     }
 }
 


### PR DESCRIPTION
Quick edit to enable fake SCSI reservations to the complete physical cluster (and not just the 1st host of the cluster).